### PR TITLE
Port to LLVM 17 and support LLVM 13-17 with dynamic and static linking

### DIFF
--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -3,36 +3,36 @@ name: C/C++ CI
 on: [push, pull_request]
 
 jobs:
-  llvm10:
+  llvm:
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 10
     strategy:
+      fail-fast: false
       matrix:
-        os: [ubuntu-latest]
+        version: [13, 14, 15, 16, 17]
+        os: [ubuntu-22.04]
     
     steps:
-    - uses: actions/checkout@v1
-    - name: install ninja
-      run: sudo apt-get -y install ninja-build
-    - name: install apt.llvm.org repo
-      run: wget https://apt.llvm.org/llvm.sh && chmod +x llvm.sh && sudo ./llvm.sh 10
-    - name: install clang-dev
-      run: sudo apt-get -y install llvm-10-dev libclang-10-dev
-    - name: build
-      run: mkdir build && cd build && cmake .. && make
-  
-  llvm11:
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [ubuntu-latest]
-    
-    steps:
-    - uses: actions/checkout@v1
-    - name: install ninja
-      run: sudo apt-get -y install ninja-build
-    - name: install apt.llvm.org repo
-      run: wget https://apt.llvm.org/llvm.sh && chmod +x llvm.sh && sudo ./llvm.sh 11
-    - name: install clang-dev
-      run: sudo apt-get -y install llvm-11-dev libclang-11-dev
-    - name: build
-      run: mkdir build && cd build && cmake .. && make
+    - uses: actions/checkout@v4
+
+    - name: Install package repository for Clang/LLVM ${{ matrix.version }}
+      run: |
+        wget https://apt.llvm.org/llvm.sh
+        chmod +x llvm.sh
+        sudo ./llvm.sh ${{ matrix.version }}
+
+    - name: Install build prerequisites and Clang/LLVM ${{ matrix.version }}
+      run: |
+        sudo apt-get -y install build-essential \
+                                cmake \
+                                libcurl4-openssl-dev \
+                                libedit-dev \
+                                llvm-${{ matrix.version }}-dev \
+                                libclang-${{ matrix.version }}-dev
+
+    - name: Build xunused for Clang/LLVM ${{ matrix.version }}
+      run: |
+        mkdir build
+        cd build
+        cmake -DLLVM_VERSION_REQUIRED=${{ matrix.version }} ..
+        make

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,40 +1,74 @@
-cmake_minimum_required(VERSION 2.8.8)
+cmake_minimum_required(VERSION 3.5)
 project(xunused)
 
-find_package(LLVM 10 CONFIG)
-if(NOT LLVM_FOUND)
-  find_package(LLVM 11 CONFIG)
-endif()
+find_package(LLVM  ${LLVM_VERSION_REQUIRED} CONFIG REQUIRED)
 message(STATUS "Found LLVM ${LLVM_PACKAGE_VERSION}")
 message(STATUS "Using LLVMConfig.cmake in: ${LLVM_DIR}")
 
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++17")
-set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+if (LLVM_VERSION_MAJOR GREATER_EQUAL 16)
+    find_package(Clang ${LLVM_VERSION_MAJOR} CONFIG REQUIRED)
+    message(STATUS "Using ClangConfig.cmake in: ${Clang_DIR}")
+endif (LLVM_VERSION_MAJOR GREATER_EQUAL 16)
+
+option(XUNUSED_LINK_LLVM_DYLIB
+       "Link against the LLVM dynamic library"
+       ${LLVM_LINK_LLVM_DYLIB})
+
+option(XUNUSED_LINK_CLANG_DYLIB
+       "Link against the clang dynamic library"
+       ${CLANG_LINK_CLANG_DYLIB})
+
+message(STATUS "Link against the LLVM dynamic library: ${XUNUSED_LINK_LLVM_DYLIB}")
+message(STATUS "Link against the Clang dynamic library: ${XUNUSED_LINK_CLANG_DYLIB}")
 
 include_directories(${LLVM_INCLUDE_DIRS})
-link_directories(${LLVM_LIBRARY_DIRS})
+include_directories(${CLANG_INCLUDE_DIRS})
+
 add_definitions(${LLVM_DEFINITIONS})
+add_definitions(${CLANG_DEFINITIONS})
+
+link_directories(${LLVM_LIBRARY_DIRS})
+link_directories(${CLANG_LIBRARY_DIRS})
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
 add_executable(xunused main.cpp)
 
-target_link_libraries(xunused
-  PRIVATE
-  clangIndex
-  clangTooling
-  clangFrontend
-  clangDriver
-  clangSerialization
-  clangParse
-  clangSema
-  clangAnalysis
-  clangASTMatchers
-  clangAST
-  clangEdit
-  clangLex
-  clangBasic  
-)
+if (XUNUSED_LINK_CLANG_DYLIB)
+    set(XUNUSED_CLANG_LIBS "clang-cpp")
+else (XUNUSED_LINK_CLANG_DYLIB)
+    set(XUNUSED_CLANG_LIBS "clangIndex"
+                           "clangTooling"
+                           "clangFrontend"
+                           "clangDriver"
+                           "clangSerialization"
+                           "clangParse"
+                           "clangSema"
+                           "clangAnalysis"
+                           "clangASTMatchers"
+                           "clangAST"
+                           "clangEdit"
+                           "clangLex"
+                           "clangBasic")
+    if (LLVM_VERSION_MAJOR GREATER_EQUAL 15)
+        list(APPEND XUNUSED_CLANG_LIBS "clangSupport")
+    endif (LLVM_VERSION_MAJOR GREATER_EQUAL 15)
+endif (XUNUSED_LINK_CLANG_DYLIB)
 
-llvm_map_components_to_libnames(llvm_libs x86asmparser support option profiledata FrontendOpenMP)
-target_link_libraries(xunused PRIVATE ${llvm_libs})
+if (XUNUSED_LINK_LLVM_DYLIB)
+    set(XUNUSED_LLVM_LIBS  "LLVM")
+else (XUNUSED_LINK_LLVM_DYLIB)
+    set(XUNUSED_LLVM_LIBS  "LLVMX86AsmParser"
+                           "LLVMSupport"
+                           "LLVMOption"
+                           "LLVMProfileData"
+                           "LLVMFrontendOpenMP")
+    if (LLVM_VERSION_MAJOR EQUAL 15)
+        list(APPEND XUNUSED_LLVM_LIBS "LLVMWindowsDriver")
+    endif (LLVM_VERSION_MAJOR EQUAL 15)
+endif (XUNUSED_LINK_LLVM_DYLIB)
+
+target_link_libraries(xunused PRIVATE ${XUNUSED_CLANG_LIBS} ${XUNUSED_LLVM_LIBS})
 
 install(TARGETS xunused DESTINATION bin)

--- a/README.md
+++ b/README.md
@@ -4,11 +4,11 @@ It is built upon clang to parse the source code (in parallel). It then shows all
 a definition but no use. Templates, virtual functions, constructors, functions with `static` linkage are
 all taken into account. If you find an issue, please open a issue on https://github.com/mgehre/xunused or file a pull request.
 
-xunused is compatible with LLVM and Clang versions 10 and 11.
+xunused is compatible with LLVM and Clang versions 13 to 17.
 
 ## Building and Installation
 First download or build the necessary versions of LLVM and Clang with development headers.
-On Debian and Ubuntu, this can easily be done via http://apt.llvm.org/ and `apt install llvm-10-dev libclang-10-dev`.
+On Debian and Ubuntu, this can easily be done via [http://apt.llvm.org](http://apt.llvm.org) and `apt install llvm-17-dev libclang-17-dev`.
 Then build via
 ```
 mkdir build
@@ -27,4 +27,4 @@ cd build
 You can specify the option `-filter` together with a regular expressions. Only files who's path is matching the regular
 expression will be analyzed. You might want to exclude your test's source code to find functions that are only used by tests but not any other code.
 
-If `xunused` complains about missing include files such as `stddef.h`, try adding `-extra-arg=-I/usr/include/clang/10/include` (or similar) to the arguments.
+If `xunused` complains about missing include files such as `stddef.h`, try adding `-extra-arg=-I/usr/include/clang/17/include` (or similar) to the arguments.

--- a/main.cpp
+++ b/main.cpp
@@ -254,7 +254,7 @@ int main(int argc, const char **argv) {
   tooling::ExecutorName.setInitialValue("all-TUs");
 #if 1
   auto Executor = clang::tooling::createExecutorFromCommandLineArgs(
-      argc, argv, llvm::cl::GeneralCategory, Overview);
+      argc, argv, llvm::cl::getGeneralCategory(), Overview);
   if (!Executor) {
     llvm::errs() << llvm::toString(Executor.takeError()) << "\n";
     return 1;


### PR DESCRIPTION
This change ports 'xunused' to LLVM 17 and ensures that the LLVM versions 13 to 17 are supported with dynamic and static linking.