### PR TITLE
Fix handling of functions with multiple definitions

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -38,7 +38,7 @@ struct DeclLoc {
 };
 
 struct DefInfo {
-  const FunctionDecl *Definition;
+  const FunctionDecl *Definition; // XXX: perhaps a dangling pointer (created during parsing a single TU)
   size_t Uses;
   std::string Name;
   std::string Filename;
@@ -52,12 +52,25 @@ std::map<std::string, DefInfo> AllDecls;
 bool getUSRForDecl(const Decl *Decl, std::string &USR) {
   llvm::SmallVector<char, 128> Buff;
 
+  // TODO: use idempotent Decl->getUSRForDecl()?
   if (index::generateUSRForDecl(Decl, Buff))
     return false;
 
   USR = std::string(Buff.data(), Buff.size());
   return true;
 }
+
+// TODO: use in Uses and Defs sets to exclude duplicates
+// (i.e., when multiple FunctionDecl reference a single object)
+struct FunctionDeclPtrLess {
+    bool operator()(const FunctionDecl *f1, const FunctionDecl *f2) const {
+        std::string USR1;
+        getUSRForDecl(f1, USR1);
+        std::string USR2;
+        getUSRForDecl(f2, USR2);
+        return USR1 < USR2;
+    }
+};
 
 /// Returns all declarations that are not the definition of F
 std::vector<DeclLoc> getDeclarations(const FunctionDecl *F,
@@ -80,10 +93,7 @@ public:
 
     std::vector<const FunctionDecl *> UnusedDefs;
 
-    std::set_difference(Defs.begin(), Defs.end(), Uses.begin(), Uses.end(),
-                        std::back_inserter(UnusedDefs));
-
-    for (auto *F : UnusedDefs) {
+    for (auto *F : Defs) {
       F = F->getDefinition();
       assert(F);
       std::string USR;
@@ -107,14 +117,9 @@ public:
     // Defs before checking which uses we need to consider in other TUs,
     // so the functions overwritting the weak definition here are marked
     // as used.
-    discard_if(Defs, [](const FunctionDecl *FD) { return FD->isWeak(); });
+    // discard_if(Defs, [](const FunctionDecl *FD) { return FD->isWeak(); });
 
-    std::vector<const FunctionDecl *> ExternalUses;
-
-    std::set_difference(Uses.begin(), Uses.end(), Defs.begin(), Defs.end(),
-                        std::back_inserter(ExternalUses));
-
-    for (auto *F : ExternalUses) {
+    for (auto *F : Uses) {
       // llvm::errs() << "ExternalUses: " << F->getNameAsString() << "\n";
       std::string USR;
       if (!getUSRForDecl(F, USR))
@@ -213,7 +218,7 @@ class XUnusedASTConsumer : public ASTConsumer {
 public:
   XUnusedASTConsumer() {
     Matcher.addMatcher(
-        functionDecl(isDefinition(), unless(isImplicit())).bind("fnDecl"),
+        functionDecl(unless(isImplicit())).bind("fnDecl"),
         &Handler);
     Matcher.addMatcher(declRefExpr().bind("declRef"), &Handler);
     Matcher.addMatcher(memberExpr().bind("memberRef"), &Handler);


### PR DESCRIPTION
FunctionDeclMatchHandler::finalize(), working at a single TU at a time,
accumulates dependencies in two separate 'Uses' 'Defs' sets:
    
* Uses: All functions that are used but not defined in the TU
* Defs: All functions that are defined but not used in the TU
    
This lacks the case when a function is defined _and_ used in the TU
at the same time. Such function was omitted and could later be
considered as 'unused', e.g., if another definition was found
in a tests 'stub' file.