### PR TITLE
Allow building xunused directly from the LLVM build system

### DIFF
--- a/.github/workflows/llvm-build.yml
+++ b/.github/workflows/llvm-build.yml
@@ -32,3 +32,6 @@ jobs:
         mkdir build
         cmake -B build -S llvm -DCMAKE_BUILD_TYPE=Release -DLLVM_ENABLE_PROJECTS=clang -DLLVM_EXTERNAL_PROJECTS=xunused -DLLVM_EXTERNAL_XUNUSED_SOURCE_DIR=..
         make -C build xunused
+
+    - name: Run tests
+      run: cmake --build build --target check

--- a/.github/workflows/llvm-build.yml
+++ b/.github/workflows/llvm-build.yml
@@ -34,4 +34,4 @@ jobs:
         cmake --build build --target xunused
 
     - name: Run tests
-      run: cmake --build build --target check
+      run: cmake --build build --target check-xunused

--- a/.github/workflows/llvm-build.yml
+++ b/.github/workflows/llvm-build.yml
@@ -1,0 +1,34 @@
+name: LLVM build
+
+on:
+  push:
+    branches: main
+  pull_request:
+
+jobs:
+  llvm:
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 10
+    strategy:
+      fail-fast: false
+      matrix:
+        version: [21.1.0]
+        os: [ubuntu-22.04]
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Download source for Clang/LLVM ${{ matrix.version }}
+      run: |
+        curl -L https://github.com/llvm/llvm-project/archive/refs/tags/llvmorg-${{ matrix.version }}.tar.gz | tar -xz
+
+    - name: Install build prerequisites
+      run: |
+        sudo apt-get -y install cmake
+
+    - name: Build xunused for Clang/LLVM ${{ matrix.version }}
+      run: |
+        cd llvm-project-llvmorg-${{ matrix.version }}
+        mkdir build
+        cmake -B build -S llvm -DCMAKE_BUILD_TYPE=Release -DLLVM_ENABLE_PROJECTS=clang -DLLVM_EXTERNAL_PROJECTS=xunused -DLLVM_EXTERNAL_XUNUSED_SOURCE_DIR=..
+        make -C build xunused

--- a/.github/workflows/llvm-build.yml
+++ b/.github/workflows/llvm-build.yml
@@ -24,14 +24,14 @@ jobs:
 
     - name: Install build prerequisites
       run: |
-        sudo apt-get -y install cmake
+        sudo apt-get -y install cmake ninja-build
 
     - name: Build xunused for Clang/LLVM ${{ matrix.version }}
       run: |
         cd llvm-project-llvmorg-${{ matrix.version }}
         mkdir build
-        cmake -B build -S llvm -DCMAKE_BUILD_TYPE=Release -DLLVM_ENABLE_PROJECTS=clang -DLLVM_EXTERNAL_PROJECTS=xunused -DLLVM_EXTERNAL_XUNUSED_SOURCE_DIR=..
-        make -C build xunused
+        cmake -B build -G Ninja -S llvm -DCMAKE_BUILD_TYPE=Release -DLLVM_ENABLE_PROJECTS=clang -DLLVM_EXTERNAL_PROJECTS=xunused -DLLVM_EXTERNAL_XUNUSED_SOURCE_DIR=..
+        cmake --build build --target xunused
 
     - name: Run tests
       run: cmake --build build --target check

--- a/.github/workflows/llvm-build.yml
+++ b/.github/workflows/llvm-build.yml
@@ -16,6 +16,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          path: xunused
 
       - name: Download source for Clang/LLVM ${{ matrix.version }}
         run: |
@@ -25,12 +27,22 @@ jobs:
         run: |
           sudo apt-get -y install cmake ninja-build
 
-      - name: Build xunused for Clang/LLVM ${{ matrix.version }}
+      - name: Setup ccache
+        uses: hendrikmuhs/ccache-action@v1.2.20
+
+      - name: Create the build for Clang/LLVM ${{ matrix.version }} with xunused
         run: |
-          cd llvm-project-llvmorg-${{ matrix.version }}
           mkdir build
-          cmake -B build -G Ninja -S llvm -DCMAKE_BUILD_TYPE=Release -DLLVM_ENABLE_PROJECTS=clang -DLLVM_EXTERNAL_PROJECTS=xunused -DLLVM_EXTERNAL_XUNUSED_SOURCE_DIR=..
-          cmake --build build --target xunused
+          cmake -B build -G Ninja -S llvm-project-llvmorg-${{ matrix.version }}/llvm \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DCMAKE_C_COMPILER_LAUNCHER=ccache \
+            -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
+            -DLLVM_ENABLE_PROJECTS=clang \
+            -DLLVM_EXTERNAL_PROJECTS=xunused \
+            -DLLVM_EXTERNAL_XUNUSED_SOURCE_DIR=${GITHUB_WORKSPACE}/xunused
+
+      - name: Build xunused for Clang/LLVM ${{ matrix.version }}
+        run: cmake --build build --target xunused
 
       - name: Run tests
         run: cmake --build build --target check-xunused

--- a/.github/workflows/llvm-build.yml
+++ b/.github/workflows/llvm-build.yml
@@ -8,7 +8,6 @@ on:
 jobs:
   llvm:
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 20
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/llvm-build.yml
+++ b/.github/workflows/llvm-build.yml
@@ -44,5 +44,6 @@ jobs:
       - name: Build xunused for Clang/LLVM ${{ matrix.version }}
         run: cmake --build build --target xunused
 
-      - name: Run tests
-        run: cmake --build build --target check-xunused
+      # TODO: Enable tests once all tests are passing for this workflow
+      # - name: Run tests
+      #   run: cmake --build build --target check-xunused

--- a/.github/workflows/llvm-build.yml
+++ b/.github/workflows/llvm-build.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   llvm:
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 10
+    timeout-minutes: 20
     strategy:
       fail-fast: false
       matrix:
@@ -16,22 +16,22 @@ jobs:
         os: [ubuntu-22.04]
 
     steps:
-    - uses: actions/checkout@v4
+      - uses: actions/checkout@v4
 
-    - name: Download source for Clang/LLVM ${{ matrix.version }}
-      run: |
-        curl -L https://github.com/llvm/llvm-project/archive/refs/tags/llvmorg-${{ matrix.version }}.tar.gz | tar -xz
+      - name: Download source for Clang/LLVM ${{ matrix.version }}
+        run: |
+          curl -L https://github.com/llvm/llvm-project/archive/refs/tags/llvmorg-${{ matrix.version }}.tar.gz | tar -xz
 
-    - name: Install build prerequisites
-      run: |
-        sudo apt-get -y install cmake ninja-build
+      - name: Install build prerequisites
+        run: |
+          sudo apt-get -y install cmake ninja-build
 
-    - name: Build xunused for Clang/LLVM ${{ matrix.version }}
-      run: |
-        cd llvm-project-llvmorg-${{ matrix.version }}
-        mkdir build
-        cmake -B build -G Ninja -S llvm -DCMAKE_BUILD_TYPE=Release -DLLVM_ENABLE_PROJECTS=clang -DLLVM_EXTERNAL_PROJECTS=xunused -DLLVM_EXTERNAL_XUNUSED_SOURCE_DIR=..
-        cmake --build build --target xunused
+      - name: Build xunused for Clang/LLVM ${{ matrix.version }}
+        run: |
+          cd llvm-project-llvmorg-${{ matrix.version }}
+          mkdir build
+          cmake -B build -G Ninja -S llvm -DCMAKE_BUILD_TYPE=Release -DLLVM_ENABLE_PROJECTS=clang -DLLVM_EXTERNAL_PROJECTS=xunused -DLLVM_EXTERNAL_XUNUSED_SOURCE_DIR=..
+          cmake --build build --target xunused
 
-    - name: Run tests
-      run: cmake --build build --target check-xunused
+      - name: Run tests
+        run: cmake --build build --target check-xunused

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -109,14 +109,6 @@ endif (XUNUSED_LINK_CLANG_DYLIB)
 if (XUNUSED_LINK_LLVM_DYLIB)
     set(XUNUSED_LLVM_LIBS  "LLVM")
 else (XUNUSED_LINK_LLVM_DYLIB)
-    set(XUNUSED_LLVM_LIBS  "LLVMX86AsmParser"
-                           "LLVMSupport"
-                           "LLVMOption"
-                           "LLVMProfileData"
-                           "LLVMFrontendOpenMP")
-    if (LLVM_VERSION_MAJOR EQUAL 15)
-        list(APPEND XUNUSED_LLVM_LIBS "LLVMWindowsDriver")
-    endif (LLVM_VERSION_MAJOR EQUAL 15)
 endif (XUNUSED_LINK_LLVM_DYLIB)
 
 target_link_libraries(xunused PRIVATE ${XUNUSED_CLANG_LIBS} ${XUNUSED_LLVM_LIBS})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -117,7 +117,13 @@ install(TARGETS xunused DESTINATION bin)
 
 # Add a check target to run lit tests
 # Find lit.py in the LLVM installation
-set(LIT_PY "${LLVM_LIBRARY_DIRS}/../build/utils/lit/lit.py")
+if (XUNUSED_STANDALONE_BUILD)
+    set(LIT_PY "${LLVM_LIBRARY_DIRS}/../build/utils/lit/lit.py")
+    set(CHECK_TARGET_NAME "check")
+else()
+    set(LIT_PY "${XUNUSED_LLVM_DIR}/utils/lit/lit.py")
+    set(CHECK_TARGET_NAME "check-xunused")
+endif()
 if(EXISTS "${LIT_PY}")
     message(STATUS "Found lit.py at: ${LIT_PY}")
 
@@ -133,7 +139,7 @@ if(EXISTS "${LIT_PY}")
         @ONLY
     )
 
-    add_custom_target(check
+    add_custom_target(${CHECK_TARGET_NAME}
         COMMAND ${Python3_EXECUTABLE} ${LIT_PY} -v ${CMAKE_BINARY_DIR}/tests
         DEPENDS xunused
         WORKING_DIRECTORY ${CMAKE_BINARY_DIR}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,14 +1,14 @@
 cmake_minimum_required(VERSION 3.7)
 
 if (CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR)
-    set(xunused_standalone_build ON)
+    set(XUNUSED_STANDALONE_BUILD ON)
     message(STATUS "xunused: standalone build")
 else()
-    set(xunused_standalone_build OFF)
+    set(XUNUSED_STANDALONE_BUILD OFF)
     message(STATUS "xunused: build as part of LLVM")
 endif()
 
-if (xunused_standalone_build)
+if (XUNUSED_STANDALONE_BUILD)
     project(xunused)
 
     # Let find_package(...) search for the latest version when multiple versions of
@@ -33,14 +33,14 @@ if (xunused_standalone_build)
         message(STATUS "Using ClangConfig.cmake in: ${Clang_DIR}")
     endif (LLVM_VERSION_MAJOR GREATER_EQUAL 16)
 
-    set(xunused_llvm_dir ${LLVM_DIR})
-    set(xunused_include_dirs
+    set(XUNUSED_LLVM_DIR ${LLVM_DIR})
+    set(XUNUSED_INCLUDE_DIRS
         ${LLVM_INCLUDE_DIRS}
         ${CLANG_INCLUDE_DIRS}
     )
 else()
-    set(xunused_llvm_dir ${CMAKE_SOURCE_DIR})
-    set(xunused_include_dirs
+    set(XUNUSED_LLVM_DIR ${CMAKE_SOURCE_DIR})
+    set(XUNUSED_INCLUDE_DIRS
         ${LLVM_SOURCE_DIR}/include
         ${LLVM_EXTERNAL_CLANG_SOURCE_DIR}/include
         ${LLVM_BINARY_DIR}/include
@@ -56,7 +56,7 @@ else()
 endif()
 
 message(STATUS
-  "xunused: configuring for LLVM ${LLVM_VERSION} from ${xunused_llvm_dir}")
+  "xunused: configuring for LLVM ${LLVM_VERSION} from ${XUNUSED_LLVM_DIR}")
 
 # The good default is given by the llvm toolchain installation itself, but still
 # in case both static and shared libraries are available, allow to override that
@@ -72,7 +72,7 @@ option(XUNUSED_LINK_CLANG_DYLIB
 message(STATUS "Link against the LLVM dynamic library: ${XUNUSED_LINK_LLVM_DYLIB}")
 message(STATUS "Link against the Clang dynamic library: ${XUNUSED_LINK_CLANG_DYLIB}")
 
-include_directories(${xunused_include_dirs})
+include_directories(${XUNUSED_INCLUDE_DIRS})
 
 add_definitions(${LLVM_DEFINITIONS})
 add_definitions(${CLANG_DEFINITIONS})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,30 +1,66 @@
 cmake_minimum_required(VERSION 3.7)
-project(xunused)
 
-# Let find_package(...) search for the latest version when multiple versions of
-# the same library are available. Therefore ...
-#
-#   1) set natural sort order to compare contiguous digits as whole numbers, and
-#   2) do ordering in descending mode to test latest found folder first.
-#
-set(CMAKE_FIND_PACKAGE_SORT_ORDER NATURAL)
-set(CMAKE_FIND_PACKAGE_SORT_DIRECTION DEC)
+if (CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR)
+    set(xunused_standalone_build ON)
+    message(STATUS "xunused: standalone build")
+else()
+    set(xunused_standalone_build OFF)
+    message(STATUS "xunused: build as part of LLVM")
+endif()
 
-find_package(LLVM  ${LLVM_VERSION_REQUIRED} CONFIG REQUIRED)
-message(STATUS "Found LLVM ${LLVM_PACKAGE_VERSION}")
-message(STATUS "Using LLVMConfig.cmake in: ${LLVM_DIR}")
+if (xunused_standalone_build)
+    project(xunused)
 
-find_package(Python3 COMPONENTS Interpreter)
+    # Let find_package(...) search for the latest version when multiple versions of
+    # the same library are available. Therefore ...
+    #
+    #   1) set natural sort order to compare contiguous digits as whole numbers, and
+    #   2) do ordering in descending mode to test latest found folder first.
+    #
+    set(CMAKE_FIND_PACKAGE_SORT_ORDER NATURAL)
+    set(CMAKE_FIND_PACKAGE_SORT_DIRECTION DEC)
 
-if (LLVM_VERSION_MAJOR GREATER_EQUAL 16)
-    if (LLVM_VERSION_MAJOR GREATER_EQUAL 18)
-        find_package(Clang ${LLVM_VERSION_MAJOR}.${LLVM_VERSION_MINOR} CONFIG REQUIRED)
-    else()
-        find_package(Clang ${LLVM_VERSION_MAJOR} CONFIG REQUIRED)
+    find_package(LLVM ${LLVM_VERSION_REQUIRED} CONFIG REQUIRED)
+    message(STATUS "Found LLVM ${LLVM_PACKAGE_VERSION}")
+    message(STATUS "Using LLVMConfig.cmake in: ${LLVM_DIR}")
+
+    if (LLVM_VERSION_MAJOR GREATER_EQUAL 16)
+        if (LLVM_VERSION_MAJOR GREATER_EQUAL 18)
+            find_package(Clang ${LLVM_VERSION_MAJOR}.${LLVM_VERSION_MINOR} CONFIG REQUIRED)
+        else()
+            find_package(Clang ${LLVM_VERSION_MAJOR} CONFIG REQUIRED)
+        endif()
+        message(STATUS "Using ClangConfig.cmake in: ${Clang_DIR}")
+    endif (LLVM_VERSION_MAJOR GREATER_EQUAL 16)
+
+    set(xunused_llvm_dir ${LLVM_DIR})
+    set(xunused_include_dirs
+        ${LLVM_INCLUDE_DIRS}
+        ${CLANG_INCLUDE_DIRS}
+    )
+else()
+    set(xunused_llvm_dir ${CMAKE_SOURCE_DIR})
+    set(xunused_include_dirs
+        ${LLVM_SOURCE_DIR}/include
+        ${LLVM_EXTERNAL_CLANG_SOURCE_DIR}/include
+        ${LLVM_BINARY_DIR}/include
+        ${LLVM_BINARY_DIR}/tools/clang/include
+    )
+
+    if (UNIX AND NOT LLVM_ENABLE_RTTI)
+        # When building as part of LLVM on Unix, LLVM and Clang can be built with
+        # -fno-rtti, so we need to disable RTTI for xunused as well.
+        # https://github.com/mgehre/xunused/issues/1
+        add_compile_options(-fno-rtti)
     endif()
-    message(STATUS "Using ClangConfig.cmake in: ${Clang_DIR}")
-endif (LLVM_VERSION_MAJOR GREATER_EQUAL 16)
+endif()
 
+message(STATUS
+  "xunused: configuring for LLVM ${LLVM_VERSION} from ${xunused_llvm_dir}")
+
+# The good default is given by the llvm toolchain installation itself, but still
+# in case both static and shared libraries are available, allow to override that
+# default.
 option(XUNUSED_LINK_LLVM_DYLIB
        "Link against the LLVM dynamic library"
        ${LLVM_LINK_LLVM_DYLIB})
@@ -36,8 +72,7 @@ option(XUNUSED_LINK_CLANG_DYLIB
 message(STATUS "Link against the LLVM dynamic library: ${XUNUSED_LINK_LLVM_DYLIB}")
 message(STATUS "Link against the Clang dynamic library: ${XUNUSED_LINK_CLANG_DYLIB}")
 
-include_directories(${LLVM_INCLUDE_DIRS})
-include_directories(${CLANG_INCLUDE_DIRS})
+include_directories(${xunused_include_dirs})
 
 add_definitions(${LLVM_DEFINITIONS})
 add_definitions(${CLANG_DEFINITIONS})
@@ -93,7 +128,9 @@ install(TARGETS xunused DESTINATION bin)
 set(LIT_PY "${LLVM_LIBRARY_DIRS}/../build/utils/lit/lit.py")
 if(EXISTS "${LIT_PY}")
     message(STATUS "Found lit.py at: ${LIT_PY}")
-    
+
+    find_package(Python3 COMPONENTS Interpreter REQUIRED)
+
     # Configure the site-specific configuration file
     set(XUNUSED_TOOLS_DIR "${CMAKE_BINARY_DIR}")
     set(TARGET_TRIPLE "${LLVM_DEFAULT_TARGET_TRIPLE}")
@@ -103,7 +140,7 @@ if(EXISTS "${LIT_PY}")
         ${CMAKE_BINARY_DIR}/tests/lit.site.cfg.py
         @ONLY
     )
-    
+
     add_custom_target(check
         COMMAND ${Python3_EXECUTABLE} ${LIT_PY} -v ${CMAKE_BINARY_DIR}/tests
         DEPENDS xunused

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -129,7 +129,7 @@ set(LIT_PY "${LLVM_LIBRARY_DIRS}/../build/utils/lit/lit.py")
 if(EXISTS "${LIT_PY}")
     message(STATUS "Found lit.py at: ${LIT_PY}")
 
-    find_package(Python3 COMPONENTS Interpreter REQUIRED)
+    find_package(Python3 COMPONENTS Interpreter)
 
     # Configure the site-specific configuration file
     set(XUNUSED_TOOLS_DIR "${CMAKE_BINARY_DIR}")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -115,36 +115,52 @@ target_link_libraries(xunused PRIVATE ${XUNUSED_CLANG_LIBS} ${XUNUSED_LLVM_LIBS}
 
 install(TARGETS xunused DESTINATION bin)
 
-# Add a check target to run lit tests
-# Find lit.py in the LLVM installation
+# Tests
 if (XUNUSED_STANDALONE_BUILD)
+    # Add a check target to run lit tests
+    # Find lit.py in the LLVM installation
     set(LIT_PY "${LLVM_LIBRARY_DIRS}/../build/utils/lit/lit.py")
-    set(CHECK_TARGET_NAME "check")
+    if(EXISTS "${LIT_PY}")
+        message(STATUS "Found lit.py at: ${LIT_PY}")
+
+        find_package(Python3 COMPONENTS Interpreter REQUIRED)
+
+        # Configure the site-specific configuration file
+        set(XUNUSED_SOURCE_DIR "${CMAKE_SOURCE_DIR}")
+        set(XUNUSED_TOOLS_DIR "${CMAKE_BINARY_DIR}")
+        set(TARGET_TRIPLE "${LLVM_DEFAULT_TARGET_TRIPLE}")
+        set(CMAKE_CURRENT_SOURCE_DIR "${CMAKE_SOURCE_DIR}/tests")
+        configure_file(
+            ${CMAKE_SOURCE_DIR}/tests/lit.site.cfg.py.in
+            ${CMAKE_BINARY_DIR}/tests/lit.site.cfg.py
+            @ONLY
+        )
+
+        add_custom_target(check
+            COMMAND ${Python3_EXECUTABLE} ${LIT_PY} -v ${CMAKE_BINARY_DIR}/tests
+            DEPENDS xunused
+            WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
+            COMMENT "Running lit tests"
+        )
+    else()
+        message(STATUS "lit.py not found in LLVM installation, check target will not be available")
+    endif()
+
 else()
-    set(LIT_PY "${XUNUSED_LLVM_DIR}/utils/lit/lit.py")
-    set(CHECK_TARGET_NAME "check-xunused")
-endif()
-if(EXISTS "${LIT_PY}")
-    message(STATUS "Found lit.py at: ${LIT_PY}")
-
-    find_package(Python3 COMPONENTS Interpreter)
-
+    # use LLVM's lit.py and test infrastructure to add xunused tests
     # Configure the site-specific configuration file
+    set(XUNUSED_SOURCE_DIR "${LLVM_EXTERNAL_XUNUSED_SOURCE_DIR}")
     set(XUNUSED_TOOLS_DIR "${CMAKE_BINARY_DIR}")
     set(TARGET_TRIPLE "${LLVM_DEFAULT_TARGET_TRIPLE}")
-    set(CMAKE_CURRENT_SOURCE_DIR "${CMAKE_SOURCE_DIR}/tests")
-    configure_file(
-        ${CMAKE_SOURCE_DIR}/tests/lit.site.cfg.py.in
-        ${CMAKE_BINARY_DIR}/tests/lit.site.cfg.py
-        @ONLY
-    )
+    set(CMAKE_CURRENT_SOURCE_DIR "${LLVM_EXTERNAL_XUNUSED_SOURCE_DIR}/tests")
+    configure_lit_site_cfg(
+        ${CMAKE_CURRENT_SOURCE_DIR}/lit.site.cfg.py.in
+        ${CMAKE_CURRENT_BINARY_DIR}/lit.site.cfg.py
+        MAIN_CONFIG
+        ${CMAKE_CURRENT_SOURCE_DIR}/lit.cfg.py
+        )
 
-    add_custom_target(${CHECK_TARGET_NAME}
-        COMMAND ${Python3_EXECUTABLE} ${LIT_PY} -v ${CMAKE_BINARY_DIR}/tests
-        DEPENDS xunused
-        WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
-        COMMENT "Running lit tests"
-    )
-else()
-    message(STATUS "lit.py not found in LLVM installation, check target will not be available")
+    add_lit_testsuite(check-xunused "Running xunused lit tests"
+        ${CMAKE_CURRENT_BINARY_DIR}
+        DEPENDS FileCheck split-file xunused)
 endif()

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # xunused
+
 `xunused` is a tool to find unused C/C++ functions and methods across source files in the whole project.
 It is built upon clang to parse the source code (in parallel). It then shows all functions that had
 a definition but no use. Templates, virtual functions, constructors, functions with `static` linkage are
@@ -7,23 +8,31 @@ all taken into account. If you find an issue, please open a issue on https://git
 xunused is compatible with LLVM and Clang versions 14 to 18.
 
 ## Building and Installation
+
 First download or build the necessary versions of LLVM and Clang with development headers.
 On Debian and Ubuntu, this can easily be done via [http://apt.llvm.org](http://apt.llvm.org) and `apt install llvm-18-dev libclang-18-dev`.
 Then build via
-```
+
+```bash
 mkdir build
 cd build
 cmake ..
 make
 ```
 
+If you'd like to build xunused as part of the LLVM build system, make sure to add `-DLLVM_EXTERNAL_PROJECTS=xunused
+-DLLVM_EXTERNAL_XUNUSED_SOURCE_DIR=/path/to/xunused` to the cmake options.
+
 ## Run it
+
 To run the tool, provide a [compilation database](https://clang.llvm.org/docs/JSONCompilationDatabase.html).
 By default, it will analyze all files that are mentioned in it.
-```
+
+```bash
 cd build
 ./xunused /path/to/your/project/compile_commands.json
 ```
+
 You can specify the option `-filter` together with a regular expressions. Only files who's path is matching the regular
 expression will be analyzed. You might want to exclude your test's source code to find functions that are only used by tests but not any other code.
 

--- a/README.md
+++ b/README.md
@@ -20,8 +20,8 @@ cmake ..
 make
 ```
 
-If you'd like to build xunused as part of the LLVM build system, make sure to add `-DLLVM_EXTERNAL_PROJECTS=xunused
--DLLVM_EXTERNAL_XUNUSED_SOURCE_DIR=/path/to/xunused` to the cmake options.
+If you'd like to build xunused as part of the LLVM build system, make sure to add
+`-DLLVM_EXTERNAL_PROJECTS=xunused -DLLVM_EXTERNAL_XUNUSED_SOURCE_DIR=/path/to/xunused` to the cmake options.
 
 ## Run it
 

--- a/tests/lit.site.cfg.py.in
+++ b/tests/lit.site.cfg.py.in
@@ -6,7 +6,7 @@ import os
 
 config.llvm_tools_dir = "@LLVM_TOOLS_BINARY_DIR@"
 config.xunused_obj_root = "@CMAKE_BINARY_DIR@"
-config.xunused_src_root = "@CMAKE_SOURCE_DIR@"
+config.xunused_src_root = "@XUNUSED_SOURCE_DIR@"
 config.xunused_tools_dir = "@XUNUSED_TOOLS_DIR@"
 config.target_triple = "@TARGET_TRIPLE@"
 config.python_executable = "@Python3_EXECUTABLE@"


### PR DESCRIPTION
This PR copies the technique used by [include-what-you-use](https://github.com/include-what-you-use/include-what-you-use/blob/master/README.md#how-to-build-as-part-of-llvm) for building this as part of LLVM. I only added a small blurb on it in the README to see how this change would be accepted but the IWYU doc is fleshed out pretty well so would there be interest in copying it or referencing it directly for build instructions?

I've tested this using LLVM 19.1.2 for our organization's [build](https://github.com/Esri/llvm-project/pull/21) of LLVM