### PR TITLE
Quit with a non-zero exit code on source compilation errors

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -213,6 +213,8 @@ public:
   std::set<const FunctionDecl *> Uses;
 };
 
+std::atomic<bool> CompilationError = false;
+
 class XUnusedASTConsumer : public ASTConsumer {
 public:
   XUnusedASTConsumer() {
@@ -227,6 +229,14 @@ public:
   }
 
   void HandleTranslationUnit(ASTContext &Context) override {
+    if (Context.getDiagnostics().hasErrorOccurred()) {
+        auto &DiagEngine = Context.getDiagnostics();
+        llvm::errs() << "Errors:" << Context.getDiagnostics().getNumErrors() << "\n";
+        unsigned DiagID = DiagEngine.getCustomDiagID(clang::DiagnosticsEngine::Fatal, "Aborting execution due to compilation error in TU.");
+        DiagEngine.Report(DiagID);
+        CompilationError = true;
+        return;
+    }
     Matcher.matchAST(Context);
     Handler.finalize(Context.getSourceManager());
   }
@@ -236,12 +246,23 @@ private:
   MatchFinder Matcher;
 };
 
+std::mutex ActionMutex;
 // For each source file provided to the tool, a new FrontendAction is created.
 class XUnusedFrontendAction : public ASTFrontendAction {
 public:
   std::unique_ptr<ASTConsumer> CreateASTConsumer(CompilerInstance & /*CI*/,
                                                  StringRef /*File*/) override {
     return std::make_unique<XUnusedASTConsumer>();
+  }
+
+  bool BeginSourceFileAction(clang::CompilerInstance &CI) override {
+      std::unique_lock<std::mutex> LockGuard(ActionMutex);
+      llvm::StringRef fileName = getCurrentFile();
+      if (CompilationError) {
+          llvm::errs() << "Skipping file: " << fileName << " due to previous compilation errors \n";
+          return false;
+      }
+      return true;
   }
 };
 
@@ -278,6 +299,7 @@ int main(int argc, const char **argv) {
 
   if (Err) {
     llvm::errs() << llvm::toString(std::move(Err)) << "\n";
+    return 1;
   }
 
   for (auto &KV : AllDecls) {
@@ -291,4 +313,5 @@ int main(int argc, const char **argv) {
       }
     }
   }
+  return 0;
 }

--- a/tests/build-error.test
+++ b/tests/build-error.test
@@ -1,6 +1,6 @@
 // This is an LLVM-style lit test.
-// The test checks that xunused returns an error
-// if there is a build error in one of the sources.
+// The test checks that xunused terminates with a non-zero exit code
+// when one of the source files triggers a compilation error.
 //
 // RUN: rm -rf %t && mkdir -p %t
 // RUN: split-file %s %t
@@ -11,7 +11,7 @@
 int main() { return 0; }
 
 //--- build-error2.cc
-#error Test compilation error
+#error Injected compilation error
 
 //--- build-error3.cc
 int main() { return 0; }

--- a/tests/build-error.test
+++ b/tests/build-error.test
@@ -1,0 +1,27 @@
+// This is an LLVM-style lit test that uses FileCheck.
+//
+// RUN: rm -rf %t && mkdir -p %t
+// RUN: split-file %s %t
+// RUN: sed -e "s|TESTDIR|%t|g" %t/compile_commands.json.in > %t/compile_commands.json
+// RUN: not xunused %t/compile_commands.json 2>&1 | FileCheck %s
+// CHECK: {{.*}}Aborting execution{{.*}}
+
+//--- build-error1.cc
+int main() { return; }
+
+//--- build-error2.cc
+int main() { return; }
+
+//--- compile_commands.json.in
+[
+  {
+    "directory": "TESTDIR",
+    "command": "cc -c TESTDIR/build-error1.cc",
+    "file": "TESTDIR/build-error1.cc"
+  },
+  {
+    "directory": "TESTDIR",
+    "command": "cc -c TESTDIR/build-error2.cc",
+    "file": "TESTDIR/build-error2.cc"
+  }
+]

--- a/tests/build-error.test
+++ b/tests/build-error.test
@@ -5,7 +5,7 @@
 // RUN: rm -rf %t && mkdir -p %t
 // RUN: split-file %s %t
 // RUN: sed -e "s|TESTDIR|%t|g" %t/compile_commands.json.in > %t/compile_commands.json
-// RUN: not xunused %t/compile_commands.json 2>&1
+// RUN: not xunused %t/compile_commands.json
 
 //--- build-error1.cc
 int main() { return 0; }

--- a/tests/build-error.test
+++ b/tests/build-error.test
@@ -1,16 +1,20 @@
-// This is an LLVM-style lit test that uses FileCheck.
+// This is an LLVM-style lit test.
+// The test checks that xunused returns an error
+// if there is a build error in one of the sources.
 //
 // RUN: rm -rf %t && mkdir -p %t
 // RUN: split-file %s %t
 // RUN: sed -e "s|TESTDIR|%t|g" %t/compile_commands.json.in > %t/compile_commands.json
-// RUN: not xunused %t/compile_commands.json 2>&1 | FileCheck %s
-// CHECK: {{.*}}Aborting execution{{.*}}
+// RUN: not xunused %t/compile_commands.json 2>&1
 
 //--- build-error1.cc
-int main() { return; }
+int main() { return 0; }
 
 //--- build-error2.cc
-int main() { return; }
+#error Test compilation error
+
+//--- build-error3.cc
+int main() { return 0; }
 
 //--- compile_commands.json.in
 [
@@ -23,5 +27,10 @@ int main() { return; }
     "directory": "TESTDIR",
     "command": "cc -c TESTDIR/build-error2.cc",
     "file": "TESTDIR/build-error2.cc"
+  },
+  {
+    "directory": "TESTDIR",
+    "command": "cc -c TESTDIR/build-error3.cc",
+    "file": "TESTDIR/build-error3.cc"
   }
 ]


### PR DESCRIPTION
Prior to this change, `xunused` would exit with code zero (indicating
success), regardless of whether LLVM successfully compiled all sources,
making it risky to rely on `xunused` in automated CI checks. Also,
compilation failures could effectively hid functions from `xunused`,
resulting in misleading `xunused` function usage reports.

Now, source compilation errors result in a non-zero exit code. They also
suppress final reports about unused functions.
